### PR TITLE
fix: button container position

### DIFF
--- a/plugins/dodge_button/index.js
+++ b/plugins/dodge_button/index.js
@@ -22,7 +22,7 @@ function generateDodgeAndExitButton(siblingDiv) {
 	const placeHolderDiv = document.createElement("div")
 
 	parentDiv.setAttribute("class", "dodge-button-container")
-	parentDiv.setAttribute("style", "position: absolute;right: 0px;bottom: 57px;display: flex;align-items: flex-end;")
+	parentDiv.setAttribute("style", "position: absolute; right: 10px; bottom: 57px; display: flex; align-items: flex-end;")
 	div.setAttribute("class", "quit-button ember-view");
 	div.setAttribute("onclick", "window.dodgeQueue()")
 	div.setAttribute("id", "dodgeButton");


### PR DESCRIPTION
Hello! 🐧
This is a fix just to align the button container with the client's default buttons, as shown in the screenshots

<div align="center">
  <table>
    <tr>
      <td>
        <div align="center">Before</div>
        <img src="https://github.com/teisseire117/league-loader-plugins/assets/71716568/3a4a275a-4ebb-45e5-bd68-003fc186b751" alt="Before">
      </td>
      <td>
        <div align="center">After</div>
        <img src="https://github.com/teisseire117/league-loader-plugins/assets/71716568/2e9183c6-d13b-4a41-bc68-cc23134a21d5" alt="After">
      </td>
    </tr>
  </table>
</div>
